### PR TITLE
fix: upgraded the version of json2csv to support super fields of the json2csv library

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "main": "./lib/express-json-csv",
   "dependencies": {
     "express": "3.4.6",
-    "json2csv": "2.2.1"
+    "json2csv": "3.3.0"
   },
   "devDependencies": {
     "grunt": "latest",


### PR DESCRIPTION
As the package.json was pointing to the older version of json2csv it was not able to process the super fields
